### PR TITLE
Extend top level api

### DIFF
--- a/provdbconnector/prov_db.py
+++ b/provdbconnector/prov_db.py
@@ -270,7 +270,7 @@ class ProvDb(object):
         doc = ProvDocument()
         return self._parse_record(doc,element)
 
-    def save_record(self, prov_record, bundle_id):
+    def save_record(self, prov_record, bundle_id=None):
         """
         Saves a realtion or a element (Entity, Agent or Activity)
 

--- a/provdbconnector/prov_db.py
+++ b/provdbconnector/prov_db.py
@@ -349,11 +349,11 @@ class ProvDb(object):
             if relation.get_type() is PROV_MENTION:
                 continue
 
-            self._save_relation(relation, bundle_id, prov_bundle.identifier)
+            self.save_relation(relation, bundle_id)
 
         return bundle_id
 
-    def _save_relation(self, prov_relation, bundle_id=None, bundle_identifier=None):
+    def save_relation(self, prov_relation, bundle_id=None):
         """
         Saves a relation between 2 nodes that are already in the database.
 
@@ -361,11 +361,15 @@ class ProvDb(object):
         :type prov_relation: ProvRelation
         :param bundle_id
         :type bundle_id: str
-        :param bundle_identifier
-        :type bundle_identifier: str
         :return: Relation id
         :rtype: str
         """
+
+        if not isinstance(prov_relation, ProvRelation):
+            raise InvalidArgumentTypeException(
+                "prov_relation was {}, expected: {}".format(type(prov_relation), type(ProvRelation)))
+
+
         # get from and to node
         from_tuple, to_tuple = prov_relation.formal_attributes[:2]
         from_qualified_name = from_tuple[1]
@@ -443,7 +447,7 @@ class ProvDb(object):
             if mention.get_type() is not PROV_MENTION:
                 continue
 
-            self._save_relation(mention)
+            self.save_relation(mention)
 
     @staticmethod
     def _get_metadata_and_attributes_for_record(prov_record, bundle_id=None):

--- a/provdbconnector/prov_db.py
+++ b/provdbconnector/prov_db.py
@@ -270,14 +270,23 @@ class ProvDb(object):
         doc = ProvDocument()
         return self._parse_record(doc,element)
 
-    def save_record(self, prov_record):
+    def save_record(self, prov_record, bundle_id):
+        """
+        Saves a realtion or a element (Entity, Agent or Activity)
+
+        :param prov_record: The prov record
+        :type prov.model.ProvRecord
+        :param bundle_id: The bundle id that you got back if you created a bundle or document
+        :type str
+        :return:
+        """
         if not isinstance(prov_record,ProvRecord):
             raise InvalidArgumentTypeException("Wrong type, expected: {}, got {}".format(type(ProvRecord), type(prov_record)))
 
         if isinstance(prov_record,ProvRelation):
-            return self.save_relation(prov_relation=prov_record)
+            return self.save_relation(prov_relation=prov_record,bundle_id=bundle_id)
         elif isinstance(prov_record,ProvElement):
-            return self.save_element(prov_element=prov_record)
+            return self.save_element(prov_element=prov_record,bundle_id=bundle_id)
         else:
             raise InvalidArgumentTypeException("Oh no... you provided a not supported prov_record type. The type was: {}".format(type(prov_record)))
 

--- a/provdbconnector/tests/test_prov_db.py
+++ b/provdbconnector/tests/test_prov_db.py
@@ -459,7 +459,9 @@ class ProvDbTests(unittest.TestCase):
             pass
 
         with self.assertRaises(InvalidArgumentTypeException):
-            self.provapi.save_record(InvalidProvRecordExtend())
+            doc = examples.primer_example()
+            identifier = doc.valid_qualified_name("prov:example")
+            self.provapi.save_record(InvalidProvRecordExtend(bundle=doc,identifier=identifier))
 
     def test_save_element(self):
         """

--- a/provdbconnector/tests/test_prov_db.py
+++ b/provdbconnector/tests/test_prov_db.py
@@ -2,7 +2,7 @@ import unittest
 from uuid import UUID
 
 import pkg_resources
-from prov.model import ProvDocument, ProvAgent, ProvEntity, ProvActivity, QualifiedName, ProvRelation
+from prov.model import ProvDocument, ProvAgent, ProvEntity, ProvActivity, QualifiedName, ProvRelation, ProvRecord
 
 from provdbconnector.tests import examples as examples
 from provdbconnector import ProvDb
@@ -443,9 +443,10 @@ class ProvDbTests(unittest.TestCase):
 
         #Save relation
         self.provapi.save_record(relation)
-        db_relation = self.provapi.get_relation(relation.identifier)
 
-        self.assertEqual(db_element, element)
+        # @todo discuss if it a get_relation method is useful, see  https://github.com/DLR-SC/prov-db-connector/issues/45
+        # db_relation = self.provapi.get_relation(relation.identifier)
+        # self.assertEqual(db_element, element)
 
     def test_save_record_invalid(self):
         with self.assertRaises(InvalidArgumentTypeException):
@@ -453,6 +454,12 @@ class ProvDbTests(unittest.TestCase):
 
         with self.assertRaises(InvalidArgumentTypeException):
             self.provapi.save_record(examples.primer_example())
+
+        class InvalidProvRecordExtend(ProvRecord):
+            pass
+
+        with self.assertRaises(InvalidArgumentTypeException):
+            self.provapi.save_record(InvalidProvRecordExtend())
 
     def test_save_element(self):
         """

--- a/provdbconnector/tests/test_prov_db.py
+++ b/provdbconnector/tests/test_prov_db.py
@@ -427,6 +427,33 @@ class ProvDbTests(unittest.TestCase):
         with self.assertRaises(InvalidArgumentTypeException):
             self.provapi.save_element("Some cool invalid argument")
 
+    def test_save_record(self):
+        """
+        Test to save a record (a element or a relation)
+        """
+        doc = examples.primer_example()
+        element = list(doc.get_records(ProvActivity)).pop()
+        relation = list(doc.get_records(ProvRelation)).pop()
+
+        #save element
+        self.provapi.save_record(element)
+        db_element = self.provapi.get_element(element.identifier)
+
+        self.assertEqual(db_element,element)
+
+        #Save relation
+        self.provapi.save_record(relation)
+        db_relation = self.provapi.get_relation(relation.identifier)
+
+        self.assertEqual(db_element, element)
+
+    def test_save_record_invalid(self):
+        with self.assertRaises(InvalidArgumentTypeException):
+            self.provapi.save_record(list())
+
+        with self.assertRaises(InvalidArgumentTypeException):
+            self.provapi.save_record(examples.primer_example())
+
     def test_save_element(self):
         """
         Try to save a single record without document_di
@@ -494,7 +521,18 @@ class ProvDbTests(unittest.TestCase):
         doc = examples.primer_example()
         relation = list(doc.get_records(ProvRelation)).pop()
 
-        self.provapi._save_relation(prov_relation=relation)
+        self.provapi.save_relation(relation)
+
+    def test_save_relation_invalid(self):
+
+        with self.assertRaises(InvalidArgumentTypeException):
+            self.provapi.save_relation(None)
+
+
+        with self.assertRaises(InvalidArgumentTypeException):
+            doc = examples.primer_example()
+            element = list(doc.get_records(ProvEntity)).pop()
+            self.provapi.save_relation(element)
 
     def test_get_metadata_and_attributes_for_record_invalid_arguments(self):
         """


### PR DESCRIPTION
Added new methods in `ProvDb` class

* `save_record(prov_record, [bundle_id])` - Saves a ProvElement (Activity, Agent, Entity) or a ProvRelation(all relation types) 
* `save_relation(prov_relation,[bundle_id])` - Saves a single ProvRelation and creates the from and to node if necessary 
