### PR TITLE
feat: Support prov namespaces with same prefix

### DIFF
--- a/provdbconnector/db_adapters/baseadapter.py
+++ b/provdbconnector/db_adapters/baseadapter.py
@@ -6,6 +6,7 @@ log = logging.getLogger(__name__).addHandler(logging.NullHandler())
 METADATA_PARENT_ID = "parent_id"
 METADATA_KEY_PROV_TYPE = "prov_type"
 METADATA_KEY_IDENTIFIER = "identifier"
+METADATA_KEY_IDENTIFIER_ORIGINAL = "identifier_original"
 METADATA_KEY_NAMESPACES = "namespaces"
 METADATA_KEY_TYPE_MAP = "type_map"
 

--- a/provdbconnector/tests/examples.py
+++ b/provdbconnector/tests/examples.py
@@ -25,6 +25,12 @@ def prov_db_unknown_prov_typ_example():
     doc.influence(influencee="ex:Entity1", influencer="ex:Entity2")
     return doc
 
+def prov_default_namespace_example(ns_postfix: str):
+    doc = ProvDocument()
+    doc.set_default_namespace("https://example.com/{0}".format(ns_postfix))
+    doc.entity(identifier="Entity1")
+    return doc
+
 
 
 def attributes_dict_example():

--- a/provdbconnector/utils/serializer.py
+++ b/provdbconnector/utils/serializer.py
@@ -412,3 +412,10 @@ def merge_record(attributes, metadata, other_attributes, other_metadata):
     merged_metadata.update({METADATA_KEY_TYPE_MAP: merged_metadata_type_map})
 
     return attributes_merged, merged_metadata
+
+def serialize_namespace(namespace: Namespace):
+    prefix = namespace.prefix
+
+    if prefix == "" or prefix is None:
+        prefix = "default"
+    return {str(prefix): str(namespace.uri)}


### PR DESCRIPTION
This closes #87 

Support different namespaces with the same prefix e.g. default
namespaces or ex:http://example.com and ex:http://some-ohter.com

