### PR TITLE
Add python 3.10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - "3.7"
 - "3.8"
 - "3.9"
-- "3.10.1"
+- "3.10"
 services:
 - docker
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
 - "3.7"
 - "3.8"
 - "3.9"
-- "3.10"
+- "3.10.1"
 services:
 - docker
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
 - 3.7
 - 3.8
 - 3.9
+- 3.10
 services:
 - docker
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 sudo: required
 python:
-- 3.6
-- 3.7
-- 3.8
-- 3.9
-- 3.10
+- "3.6"
+- "3.7"
+- "3.8"
+- "3.9"
+- "3.10"
 services:
 - docker
 before_install:

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9'
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10'
     ],
     license="Apache License 2.0",
 


### PR DESCRIPTION
Build fails because of missing python 3.10 support of travis-ci, see: https://travis-ci.community/t/add-python-3-10/12220/10 
Until the issue with the build is not resolved this merge request will stay open. 